### PR TITLE
Add run target and update cross compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CROSS_COMPILE ?= aarch64-none-elf-
+CROSS_COMPILE ?= aarch64-linux-gnu-
 CC = $(CROSS_COMPILE)gcc
 LD = $(CROSS_COMPILE)gcc
 OBJCOPY = $(CROSS_COMPILE)objcopy
@@ -8,6 +8,10 @@ LDFLAGS = -T src/kernel.ld
 OBJ = src/start.o src/main.o
 
 all: kernel8.img
+
+run: kernel8.img
+	qemu-system-aarch64 -M virt -cpu cortex-a72 -m 512M \
+	  -device ramfb -display sdl -kernel kernel8.img
 
 kernel8.img: kernel8.elf
 	$(OBJCOPY) -O binary $< $@

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small ARM64 kernel example.
 
 ## Building
 
-Install an ARM64 cross compiler (e.g. `aarch64-none-elf-gcc`) and run:
+Install an ARM64 cross compiler (e.g. `aarch64-linux-gnu-gcc`) and run:
 
 ```
 make
@@ -14,8 +14,8 @@ This produces `kernel8.img`.
 
 ## Running with QEMU
 
-Launch the image with:
+Launch QEMU with:
 
 ```
-qemu-system-aarch64 -M virt -cpu cortex-a72 -m 512M -device ramfb -display sdl -kernel kernel8.img
+make run
 ```


### PR DESCRIPTION
## Summary
- switch default cross compiler to `aarch64-linux-gnu-`
- add `run` target for launching QEMU
- update README to use new toolchain and mention `make run`

## Testing
- `make clean && make`
- `timeout 5 make run` *(fails: Could not open option rom 'vgabios-ramfb.bin', error: XDG_RUNTIME_DIR is invalid or not set)*

------
https://chatgpt.com/codex/tasks/task_e_68450f8608bc8324b0ca5233137d3e39