### PR TITLE
Use FDT to set framebuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ This produces `kernel8.img`.
 
 ## Running with QEMU
 
+The kernel expects the pointer to QEMU's device tree blob in register `x0` on
+startup. It parses the tree to locate the `simple-framebuffer` node provided by
+QEMU's `-device ramfb` option and uses that framebuffer for output.
+
 Launch QEMU with:
 
 ```
 make run
 ```
+
+The `run` target already enables the RAM framebuffer device so the kernel can
+display text immediately.

--- a/src/main.c
+++ b/src/main.c
@@ -1,8 +1,112 @@
 #include <stdint.h>
 #include "font.h"
 
-#define FB_BASE ((volatile uint32_t *)0xFF000000)
-#define FB_WIDTH 1024
+static volatile uint32_t *fb_base;
+static uint32_t fb_width;
+static uint32_t fb_height;
+
+static int streq(const char *a, const char *b)
+{
+    while (*a && *b && *a == *b) {
+        a++; b++;
+    }
+    return *a == *b;
+}
+
+static unsigned int cstrlen(const char *s)
+{
+    unsigned int n = 0;
+    while (s[n])
+        n++;
+    return n;
+}
+
+static uint32_t fdt32_to_cpu(uint32_t x)
+{
+    return __builtin_bswap32(x);
+}
+
+struct fdt_header {
+    uint32_t magic;
+    uint32_t totalsize;
+    uint32_t off_dt_struct;
+    uint32_t off_dt_strings;
+    uint32_t off_mem_rsvmap;
+    uint32_t version;
+    uint32_t last_comp_version;
+    uint32_t boot_cpuid_phys;
+    uint32_t size_dt_strings;
+    uint32_t size_dt_struct;
+};
+
+#define FDT_MAGIC 0xd00dfeed
+#define FDT_BEGIN_NODE  1
+#define FDT_END_NODE    2
+#define FDT_PROP        3
+#define FDT_NOP         4
+#define FDT_END         9
+
+static void parse_fdt(void *fdt)
+{
+    const struct fdt_header *hdr = (const struct fdt_header *)fdt;
+    if (fdt32_to_cpu(hdr->magic) != FDT_MAGIC)
+        return;
+
+    const uint32_t *p = (const uint32_t *)((char *)fdt + fdt32_to_cpu(hdr->off_dt_struct));
+    const char *strings = (const char *)fdt + fdt32_to_cpu(hdr->off_dt_strings);
+
+    int depth = 0;
+    int sf_depth = -1;
+    fb_base = 0;
+    fb_width = fb_height = 0;
+
+    while (1) {
+        uint32_t token = fdt32_to_cpu(*p++);
+        if (token == FDT_END)
+            break;
+        if (token == FDT_NOP)
+            continue;
+        if (token == FDT_BEGIN_NODE) {
+            const char *name = (const char *)p;
+            unsigned int l = cstrlen(name);
+            p = (const uint32_t *)(((uintptr_t)p + l + 4) & ~3);
+            depth++;
+        } else if (token == FDT_END_NODE) {
+            if (sf_depth >= 0 && depth == sf_depth)
+                break;
+            depth--;
+        } else if (token == FDT_PROP) {
+            uint32_t len = fdt32_to_cpu(*p++);
+            uint32_t nameoff = fdt32_to_cpu(*p++);
+            const char *propname = strings + nameoff;
+            const uint8_t *data = (const uint8_t *)p;
+            p = (const uint32_t *)(((uintptr_t)p + len + 3) & ~3);
+
+            if (sf_depth < 0 && streq(propname, "compatible")) {
+                const char *s = (const char *)data;
+                while (s < (const char *)data + len) {
+                    if (streq(s, "simple-framebuffer")) {
+                        sf_depth = depth;
+                        break;
+                    }
+                    unsigned int sl = cstrlen(s);
+                    s += sl + 1;
+                }
+            } else if (sf_depth == depth) {
+                if (streq(propname, "reg")) {
+                    const uint32_t *cells = (const uint32_t *)data;
+                    uint64_t addr = ((uint64_t)fdt32_to_cpu(cells[0]) << 32) |
+                                     fdt32_to_cpu(cells[1]);
+                    fb_base = (volatile uint32_t *)(uintptr_t)addr;
+                } else if (streq(propname, "width")) {
+                    fb_width = fdt32_to_cpu(*(const uint32_t *)data);
+                } else if (streq(propname, "height")) {
+                    fb_height = fdt32_to_cpu(*(const uint32_t *)data);
+                }
+            }
+        }
+    }
+}
 
 static void draw_char(int x, int y, char c, uint32_t color)
 {
@@ -11,17 +115,22 @@ static void draw_char(int x, int y, char c, uint32_t color)
         uint8_t bits = bitmap[row];
         for (int col = 0; col < 8; col++) {
             if (bits & (1 << (7 - col))) {
-                FB_BASE[(y + row) * FB_WIDTH + x + col] = color;
+                fb_base[(y + row) * fb_width + x + col] = color;
             }
         }
     }
 }
 
-void kernel_main(void)
+void kernel_main(void *fdt)
 {
     const char *msg = "Hello";
-    for (int i = 0; i < FB_WIDTH * 768; i++)
-        FB_BASE[i] = 0; // clear screen
+
+    parse_fdt(fdt);
+    if (!fb_base || !fb_width || !fb_height)
+        return;
+
+    for (uint32_t i = 0; i < fb_width * fb_height; i++)
+        fb_base[i] = 0; // clear screen
 
     for (int i = 0; msg[i]; i++)
         draw_char(i * 8 + 10, 10, msg[i], 0x00FFFFFF);

--- a/src/start.S
+++ b/src/start.S
@@ -2,8 +2,10 @@
 
 .section .text
 _start:
+    mov x1, x0            // preserve FDT pointer from QEMU
     ldr x0, =stack_top
     mov sp, x0
+    mov x0, x1            // pass FDT pointer to kernel_main
     bl kernel_main
 1:
     wfe


### PR DESCRIPTION
## Summary
- forward QEMU's device tree pointer from `_start` to `kernel_main`
- parse the FDT to locate the `simple-framebuffer` node
- draw using the framebuffer address, width and height from the device tree
- document the new expectation of the FDT pointer and RAMFB device

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68451121a81483248b6bde18bd619d15