### PR TITLE
Update README on framebuffer setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ make run
 
 The `run` target already enables the RAM framebuffer device so the kernel can
 display text immediately.
+
+## Framebuffer setup
+
+At boot QEMU passes a pointer to its device tree in `x0`. The kernel parses the tree in `src/main.c` to find the `simple-framebuffer` node. The `reg` property of that node provides the framebuffer address along with the display size.
+
+This node is created only when QEMU is started with `-device ramfb`. The `make run` target includes this option so the kernel can locate the framebuffer and draw text.


### PR DESCRIPTION
## Summary
- document how the framebuffer base address is read from the device tree
- note that `make run` passes `-device ramfb` so the framebuffer node exists

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_684512add4708324a391a0d7a0563c4d