### PR TITLE
Zero BSS in start code

### DIFF
--- a/src/start.S
+++ b/src/start.S
@@ -5,11 +5,21 @@ _start:
     mov x1, x0            // preserve FDT pointer from QEMU
     ldr x0, =stack_top
     mov sp, x0
+
+    ldr x2, =__bss_start
+    ldr x3, =__bss_end
+1:
+    cmp x2, x3
+    b.hs 2f
+    str xzr, [x2], #8
+    b   1b
+2:
+
     mov x0, x1            // pass FDT pointer to kernel_main
     bl kernel_main
-1:
+3:
     wfe
-    b 1b
+    b 3b
 
 .section .bss
     .align 12


### PR DESCRIPTION
## Summary
- zero the BSS before calling `kernel_main`

## Testing
- `apt-get update`
- `apt-get install -y gcc-aarch64-linux-gnu`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6845145e7990832483a3a597124b3f0f